### PR TITLE
Add missing quote to fix formatting

### DIFF
--- a/src/03-setup/linux.md
+++ b/src/03-setup/linux.md
@@ -128,7 +128,7 @@ EOL
 
 Now check the results:
 
-``
+```
 $ cat /etc/udev/rules.d/99-openocd.rules
 # STM32F3DISCOVERY rev A/B - ST-LINK/V2
 ATTRS{idVendor}=="0483", ATTRS{idProduct}=="3748", GROUP="dialout"


### PR DESCRIPTION
The second code block in the fedora section is missing a backtick, causing the formatting to mess up and look like section changes. This is a bit confusing for someone trying to follow the instructions, but, fortunately, easy to fix.